### PR TITLE
fix typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ fastbootd: $(FILES)
 	$(CC) -std=gnu99 $(FILES) -o $(@)
 
 install: fastbootd
-	cp fastboot $(PREFIX)/bin
+	cp fastbootd $(PREFIX)/bin
 
 clean:
 	-rm fastbootd


### PR DESCRIPTION
make install would try to copy fastboot but fastbootd is outputted so changed fastboot -> fastbootd